### PR TITLE
Vidas para el juego rapido

### DIFF
--- a/Assets/Database/users.json
+++ b/Assets/Database/users.json
@@ -10,6 +10,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -60,6 +62,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 450,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Female_av",
             "nivelJugador": 1,
             "niveles": [
@@ -110,6 +114,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -160,6 +166,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 350,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -210,6 +218,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -260,6 +270,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -310,6 +322,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -360,6 +374,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [
@@ -410,6 +426,8 @@
             "expMax": null,
             "expMin": null,
             "expCurrent": null,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": null,
             "niveles": null,
@@ -426,6 +444,8 @@
             "expMax": 1250,
             "expMin": 500,
             "expCurrent": 600,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 2,
             "niveles": [
@@ -476,6 +496,8 @@
             "expMax": 500,
             "expMin": 0,
             "expCurrent": 0,
+            "quickGameLives": 3,
+            "timeOfLastLiveLost": [],
             "avatarImg": "Default",
             "nivelJugador": 1,
             "niveles": [

--- a/Assets/Escenarios/ES1/Scripts/Database.cs
+++ b/Assets/Escenarios/ES1/Scripts/Database.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
+using System;
+using System.Linq;
 
 [System.Serializable]
 public struct ListaMisiones
@@ -45,6 +47,8 @@ public class User
     public int expMax;
     public int expMin;
     public int expCurrent;
+    public int quickGameLives;
+    public List<string> timeOfLastLiveLost;
     public string avatarImg;
     public int nivelJugador;
     public int[] niveles;
@@ -109,6 +113,30 @@ public class Database : MonoBehaviour
 
     }
 
+    public static void setFirstTime(int userId) {
+        userBase.users[userId].timeOfLastLiveLost[0] = DateTime.Now.ToString();
+    }
+    public static void setCurrentLives(int userId, int lives) {
+        userBase.users[userId].quickGameLives = lives;
+    }
+    public static void clearTimeLastLiveLost(int userId) {
+        userBase.users[userId].timeOfLastLiveLost.Clear();
+        
+    }
+    public static void removeTimeLastLiveLost(int userId, int howMany) {
+        for (int i = 0; i < howMany; i++) {
+            userBase.users[userId].timeOfLastLiveLost.RemoveAt(0);
+        }
+    }
+    public static void addTimeLastLiveLost(int userId) {
+        userBase.users[userId].timeOfLastLiveLost.Add(DateTime.Now.ToString());
+    }
+    public static int getCurrentLives(int userId) {
+        return userBase.users[userId].quickGameLives;
+    }
+    public static List<string> getTimeOfLastLiveLost(int userId) {
+        return userBase.users[userId].timeOfLastLiveLost;
+    }
     public static bool isAdmin(int userId) {
         if (userBase.users[userId].tipo == "admin") {
             return true;

--- a/Assets/Escenarios/ES1/Scripts/Database.cs
+++ b/Assets/Escenarios/ES1/Scripts/Database.cs
@@ -336,7 +336,7 @@ public class Database : MonoBehaviour
         nUser.avatarImg = "Default";
         nUser.expCurrent = 0;
         nUser.quickGameLives = 3;
-        nUser.timeOfLastLiveLost = [];
+        nUser.timeOfLastLiveLost = new List<string>();
         nUser.nivelJugador = 1;
         int[] niv = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         nUser.niveles = niv;

--- a/Assets/Escenarios/ES1/Scripts/Database.cs
+++ b/Assets/Escenarios/ES1/Scripts/Database.cs
@@ -335,6 +335,8 @@ public class Database : MonoBehaviour
         nUser.expMin = 0;
         nUser.avatarImg = "Default";
         nUser.expCurrent = 0;
+        nUser.quickGameLives = 3;
+        nUser.timeOfLastLiveLost = [];
         nUser.nivelJugador = 1;
         int[] niv = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         nUser.niveles = niv;

--- a/Assets/Escenarios/ES1/Scripts/GameMind.cs
+++ b/Assets/Escenarios/ES1/Scripts/GameMind.cs
@@ -173,7 +173,7 @@ public class GameMind : MonoBehaviour {
             GlobalVariables.username = u;
             GlobalVariables.usernameId = id;
             GlobalVariables.turno = getTurno();
-    	    //Debug.Log("usuario " + GlobalVariables.username);
+            GlobalVariables.currentQuickGameLives = Database.getCurrentLives(id);
             SceneManager.LoadScene("Menu");
         }
         // Debug.Log("this user has " + Database.getCurrentAchivements() + "achivmenets");

--- a/Assets/Escenarios/ES1/Scripts/GlobalVariables.cs
+++ b/Assets/Escenarios/ES1/Scripts/GlobalVariables.cs
@@ -16,6 +16,7 @@ public class GlobalVariables : MonoBehaviour {
     public static string avatarImg = "Default";
     public static int usernameId;
     public static bool instructions = false;
+    public static int currentQuickGameLives = 0;
     //Estos son para lo colaborativo
     public static string Escenario = "0";
     public static int Caso = 0;

--- a/Assets/Escenarios/ES1/Scripts/QuestionManager.cs
+++ b/Assets/Escenarios/ES1/Scripts/QuestionManager.cs
@@ -213,6 +213,10 @@ public class QuestionManager : MonoBehaviour {
 
         if(GlobalVariables.lives <= 0 && MenuManager.quickMode)
         {
+            GlobalVariables.currentQuickGameLives--;
+            Database.setCurrentLives(GlobalVariables.usernameId, GlobalVariables.currentQuickGameLives);
+            Database.addTimeLastLiveLost(GlobalVariables.usernameId);
+            GameMind.saveData();
             SceneManager.LoadScene("LoseQuickMode");
         }
 

--- a/Assets/Escenarios/ES1/Scripts/WinCase.cs
+++ b/Assets/Escenarios/ES1/Scripts/WinCase.cs
@@ -451,7 +451,9 @@ public class WinCase : MonoBehaviour {
         //
         //Rand = 1;
         //
-        GameMind.setStarted(Rand);
+        if (!Database.isAdmin(GlobalVariables.usernameId)) {
+            GameMind.setStarted(Rand);
+        }
         GameMind.saveData();
         GlobalVariables.Caso = Rand;
         HelpManager.ExisteAyuda(Rand.ToString());

--- a/Assets/Resources/Prefabs/Lives.prefab
+++ b/Assets/Resources/Prefabs/Lives.prefab
@@ -1,0 +1,631 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4877159016569789698
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159016569789701}
+  - component: {fileID: 4877159016569789702}
+  - component: {fileID: 4877159016569789703}
+  - component: {fileID: 4877159016569789700}
+  m_Layer: 5
+  m_Name: Timer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159016569789701
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016569789698}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4877159018114391323}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00007953727, y: -49.450012}
+  m_SizeDelta: {x: 400, y: 136}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159016569789702
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016569789698}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159016569789703
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016569789698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 1:30:20
+--- !u!114 &4877159016569789700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016569789698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393bf7d0117440542aadb85ae05c96ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4877159016661466436
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159016661466439}
+  - component: {fileID: 4877159016661466489}
+  - component: {fileID: 4877159016661466438}
+  m_Layer: 5
+  m_Name: Live (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159016661466439
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016661466436}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4877159017464937482}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 144, y: 0}
+  m_SizeDelta: {x: 112, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159016661466489
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016661466436}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159016661466438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159016661466436}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4877159017194296978
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159017194296981}
+  - component: {fileID: 4877159017194296983}
+  - component: {fileID: 4877159017194296980}
+  m_Layer: 5
+  m_Name: Desc
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159017194296981
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159017194296978}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4877159018114391323}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00008745227, y: 67.99998}
+  m_SizeDelta: {x: 400, y: 98.9}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159017194296983
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159017194296978}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159017194296980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159017194296978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Tiempo faltante para regenerar todas las vidas: '
+--- !u!1 &4877159017464937483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159017464937482}
+  - component: {fileID: 4877159017464937485}
+  - component: {fileID: 4877159017464937484}
+  m_Layer: 5
+  m_Name: Lives Sprites
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159017464937482
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159017464937483}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4877159018313895635}
+  - {fileID: 4877159018123835775}
+  - {fileID: 4877159016661466439}
+  m_Father: {fileID: 4877159018227847040}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000022603, y: 66.5}
+  m_SizeDelta: {x: 400, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159017464937485
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159017464937483}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159017464937484
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159017464937483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f706e154982af194bbdcd5703e4b90e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4877159018114391320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159018114391323}
+  - component: {fileID: 4877159018114391325}
+  m_Layer: 5
+  m_Name: Texts
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159018114391323
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018114391320}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4877159017194296981}
+  - {fileID: 4877159016569789701}
+  m_Father: {fileID: 4877159018227847040}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000030517578, y: -182.50002}
+  m_SizeDelta: {x: 400, y: 234}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159018114391325
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018114391320}
+  m_CullTransparentMesh: 0
+--- !u!1 &4877159018123835772
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159018123835775}
+  - component: {fileID: 4877159018123835761}
+  - component: {fileID: 4877159018123835774}
+  m_Layer: 5
+  m_Name: Live (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159018123835775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018123835772}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4877159017464937482}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 112, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159018123835761
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018123835772}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159018123835774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018123835772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4877159018227847041
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159018227847040}
+  - component: {fileID: 4877159018227847042}
+  - component: {fileID: 4877159018227847043}
+  m_Layer: 5
+  m_Name: Lives
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159018227847040
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018227847041}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4877159018407202036}
+  - {fileID: 4877159017464937482}
+  - {fileID: 4877159018114391323}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 550, y: -99.506}
+  m_SizeDelta: {x: 400, y: 599}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159018227847042
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018227847041}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159018227847043
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018227847041}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4c027cbff57d2046ac5df791787b4a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4877159018313895632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159018313895635}
+  - component: {fileID: 4877159018313895637}
+  - component: {fileID: 4877159018313895634}
+  m_Layer: 5
+  m_Name: Live
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159018313895635
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018313895632}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4877159017464937482}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -144.00006, y: 0.44996643}
+  m_SizeDelta: {x: 112, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159018313895637
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018313895632}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159018313895634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018313895632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4877159018407202037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4877159018407202036}
+  - component: {fileID: 4877159018407202038}
+  - component: {fileID: 4877159018407202039}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4877159018407202036
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018407202037}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4877159018227847040}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000030517578, y: 249.50002}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4877159018407202038
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018407202037}
+  m_CullTransparentMesh: 0
+--- !u!114 &4877159018407202039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4877159018407202037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 39
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Vidas del modo rapido

--- a/Assets/Resources/Prefabs/Lives.prefab.meta
+++ b/Assets/Resources/Prefabs/Lives.prefab.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: fbfb41c971b8d0044b139b66934e87c1
-folderAsset: yes
-DefaultImporter:
+guid: e53800c3f16e410478cc76a676d56757
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/Scenes/Expbar tesst.unity
+++ b/Assets/Scenes/Expbar tesst.unity
@@ -121,6 +121,66 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &44551250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 44551251}
+  - component: {fileID: 44551252}
+  - component: {fileID: 44551253}
+  m_Layer: 5
+  m_Name: Lives Sprites
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &44551251
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 44551250}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1342291594}
+  - {fileID: 1542310182}
+  - {fileID: 847498526}
+  m_Father: {fileID: 1428209625}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000030517578, y: 117.00001}
+  m_SizeDelta: {x: 400, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &44551252
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 44551250}
+  m_CullTransparentMesh: 0
+--- !u!114 &44551253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 44551250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f706e154982af194bbdcd5703e4b90e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &218409066 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7638608110923304313, guid: d565ee7fdf6180849be76b67daffbb8d,
@@ -199,6 +259,83 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 319633966}
+  m_CullTransparentMesh: 0
+--- !u!1 &323315403
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 323315404}
+  - component: {fileID: 323315406}
+  - component: {fileID: 323315405}
+  m_Layer: 5
+  m_Name: Desc
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &323315404
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 323315403}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1551756610}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00008745227, y: 67.99998}
+  m_SizeDelta: {x: 400, y: 98.9}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &323315405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 323315403}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Tiempo faltante para regenerar todas las vidas: '
+--- !u!222 &323315406
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 323315403}
   m_CullTransparentMesh: 0
 --- !u!1 &443376063
 GameObject:
@@ -510,6 +647,169 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 798742051}
   m_CullTransparentMesh: 0
+--- !u!1 &847498525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 847498526}
+  - component: {fileID: 847498528}
+  - component: {fileID: 847498527}
+  m_Layer: 5
+  m_Name: Live (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &847498526
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847498525}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 44551251}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 144, y: 0}
+  m_SizeDelta: {x: 112, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &847498527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847498525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &847498528
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 847498525}
+  m_CullTransparentMesh: 0
+--- !u!1 &940354907
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 940354908}
+  - component: {fileID: 940354911}
+  - component: {fileID: 940354910}
+  - component: {fileID: 940354909}
+  m_Layer: 5
+  m_Name: Timer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &940354908
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940354907}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1551756610}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00007953727, y: -49.450012}
+  m_SizeDelta: {x: 400, y: 136}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &940354909
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940354907}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393bf7d0117440542aadb85ae05c96ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &940354910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940354907}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 1:30:20
+--- !u!222 &940354911
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940354907}
+  m_CullTransparentMesh: 0
 --- !u!1 &1115235182
 GameObject:
   m_ObjectHideFlags: 0
@@ -717,6 +1017,79 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1176470511}
   m_CullTransparentMesh: 0
+--- !u!1 &1342291593
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1342291594}
+  - component: {fileID: 1342291596}
+  - component: {fileID: 1342291595}
+  m_Layer: 5
+  m_Name: Live
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1342291594
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1342291593}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 44551251}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -144.00006, y: 0.44996643}
+  m_SizeDelta: {x: 112, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1342291595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1342291593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1342291596
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1342291593}
+  m_CullTransparentMesh: 0
 --- !u!1 &1362056279
 GameObject:
   m_ObjectHideFlags: 0
@@ -752,6 +1125,184 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1428209624
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1428209625}
+  - component: {fileID: 1428209627}
+  - component: {fileID: 1428209626}
+  m_Layer: 5
+  m_Name: Lives
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1428209625
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1428209624}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 44551251}
+  - {fileID: 1551756610}
+  m_Father: {fileID: 1662054823}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 476, y: -49.4}
+  m_SizeDelta: {x: 400, y: 498.9}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1428209626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1428209624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4c027cbff57d2046ac5df791787b4a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!222 &1428209627
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1428209624}
+  m_CullTransparentMesh: 0
+--- !u!1 &1542310181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1542310182}
+  - component: {fileID: 1542310184}
+  - component: {fileID: 1542310183}
+  m_Layer: 5
+  m_Name: Live (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1542310182
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542310181}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 44551251}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 112, y: 264}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1542310183
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542310181}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1542310184
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542310181}
+  m_CullTransparentMesh: 0
+--- !u!1 &1551756609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1551756610}
+  - component: {fileID: 1551756612}
+  m_Layer: 5
+  m_Name: Texts
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1551756610
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1551756609}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 323315404}
+  - {fileID: 940354908}
+  m_Father: {fileID: 1428209625}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000030517578, y: -131.99998}
+  m_SizeDelta: {x: 400, y: 234}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1551756612
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1551756609}
+  m_CullTransparentMesh: 0
 --- !u!1 &1590874781
 GameObject:
   m_ObjectHideFlags: 0
@@ -924,6 +1475,7 @@ RectTransform:
   - {fileID: 1362056280}
   - {fileID: 798742052}
   - {fileID: 218409066}
+  - {fileID: 1428209625}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1333,6 +1885,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: PlayerLvl&Exp
+      objectReference: {fileID: 0}
+    - target: {fileID: 7638608111093529849, guid: d565ee7fdf6180849be76b67daffbb8d,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d565ee7fdf6180849be76b67daffbb8d, type: 3}

--- a/Assets/Scenes/Expbar tesst.unity
+++ b/Assets/Scenes/Expbar tesst.unity
@@ -154,11 +154,11 @@ RectTransform:
   - {fileID: 1542310182}
   - {fileID: 847498526}
   m_Father: {fileID: 1428209625}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000030517578, y: 117.00001}
+  m_AnchoredPosition: {x: -0.000022603, y: 66.5}
   m_SizeDelta: {x: 400, y: 264}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &44551252
@@ -1017,6 +1017,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1176470511}
   m_CullTransparentMesh: 0
+--- !u!1 &1257372844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1257372845}
+  - component: {fileID: 1257372847}
+  - component: {fileID: 1257372846}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1257372845
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257372844}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1428209625}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000030517578, y: 249.50002}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1257372846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257372844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 39
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Vidas del modo rapido
+--- !u!222 &1257372847
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257372844}
+  m_CullTransparentMesh: 0
 --- !u!1 &1342291593
 GameObject:
   m_ObjectHideFlags: 0
@@ -1154,6 +1231,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1257372845}
   - {fileID: 44551251}
   - {fileID: 1551756610}
   m_Father: {fileID: 1662054823}
@@ -1161,8 +1239,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 476, y: -49.4}
-  m_SizeDelta: {x: 400, y: 498.9}
+  m_AnchoredPosition: {x: 550, y: -99.506}
+  m_SizeDelta: {x: 400, y: 599}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1428209626
 MonoBehaviour:
@@ -1288,11 +1366,11 @@ RectTransform:
   - {fileID: 323315404}
   - {fileID: 940354908}
   m_Father: {fileID: 1428209625}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000030517578, y: -131.99998}
+  m_AnchoredPosition: {x: 0.000030517578, y: -182.50002}
   m_SizeDelta: {x: 400, y: 234}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1551756612

--- a/Assets/Scenes/Expbar tesst.unity
+++ b/Assets/Scenes/Expbar tesst.unity
@@ -121,66 +121,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &44551250
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 44551251}
-  - component: {fileID: 44551252}
-  - component: {fileID: 44551253}
-  m_Layer: 5
-  m_Name: Lives Sprites
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &44551251
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 44551250}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1342291594}
-  - {fileID: 1542310182}
-  - {fileID: 847498526}
-  m_Father: {fileID: 1428209625}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.000022603, y: 66.5}
-  m_SizeDelta: {x: 400, y: 264}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &44551252
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 44551250}
-  m_CullTransparentMesh: 0
---- !u!114 &44551253
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 44551250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f706e154982af194bbdcd5703e4b90e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &218409066 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7638608110923304313, guid: d565ee7fdf6180849be76b67daffbb8d,
@@ -259,83 +199,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 319633966}
-  m_CullTransparentMesh: 0
---- !u!1 &323315403
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 323315404}
-  - component: {fileID: 323315406}
-  - component: {fileID: 323315405}
-  m_Layer: 5
-  m_Name: Desc
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &323315404
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 323315403}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1551756610}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.00008745227, y: 67.99998}
-  m_SizeDelta: {x: 400, y: 98.9}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &323315405
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 323315403}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 100
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'Tiempo faltante para regenerar todas las vidas: '
---- !u!222 &323315406
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 323315403}
   m_CullTransparentMesh: 0
 --- !u!1 &443376063
 GameObject:
@@ -647,169 +510,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 798742051}
   m_CullTransparentMesh: 0
---- !u!1 &847498525
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 847498526}
-  - component: {fileID: 847498528}
-  - component: {fileID: 847498527}
-  m_Layer: 5
-  m_Name: Live (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &847498526
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847498525}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 44551251}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 144, y: 0}
-  m_SizeDelta: {x: 112, y: 264}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &847498527
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847498525}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &847498528
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 847498525}
-  m_CullTransparentMesh: 0
---- !u!1 &940354907
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 940354908}
-  - component: {fileID: 940354911}
-  - component: {fileID: 940354910}
-  - component: {fileID: 940354909}
-  m_Layer: 5
-  m_Name: Timer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &940354908
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940354907}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1551756610}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.00007953727, y: -49.450012}
-  m_SizeDelta: {x: 400, y: 136}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &940354909
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940354907}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 393bf7d0117440542aadb85ae05c96ae, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &940354910
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940354907}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 100
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 1:30:20
---- !u!222 &940354911
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940354907}
-  m_CullTransparentMesh: 0
 --- !u!1 &1115235182
 GameObject:
   m_ObjectHideFlags: 0
@@ -1017,156 +717,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1176470511}
   m_CullTransparentMesh: 0
---- !u!1 &1257372844
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1257372845}
-  - component: {fileID: 1257372847}
-  - component: {fileID: 1257372846}
-  m_Layer: 5
-  m_Name: Title
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1257372845
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1257372844}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1428209625}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.000030517578, y: 249.50002}
-  m_SizeDelta: {x: 400, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1257372846
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1257372844}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 39
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Vidas del modo rapido
---- !u!222 &1257372847
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1257372844}
-  m_CullTransparentMesh: 0
---- !u!1 &1342291593
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1342291594}
-  - component: {fileID: 1342291596}
-  - component: {fileID: 1342291595}
-  m_Layer: 5
-  m_Name: Live
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1342291594
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1342291593}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 44551251}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -144.00006, y: 0.44996643}
-  m_SizeDelta: {x: 112, y: 264}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1342291595
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1342291593}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1342291596
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1342291593}
-  m_CullTransparentMesh: 0
 --- !u!1 &1362056279
 GameObject:
   m_ObjectHideFlags: 0
@@ -1202,185 +752,12 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1428209624
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1428209625}
-  - component: {fileID: 1428209627}
-  - component: {fileID: 1428209626}
-  m_Layer: 5
-  m_Name: Lives
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1428209625
+--- !u!224 &1428209625 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+    type: 3}
+  m_PrefabInstance: {fileID: 4877159017508565081}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428209624}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1257372845}
-  - {fileID: 44551251}
-  - {fileID: 1551756610}
-  m_Father: {fileID: 1662054823}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 550, y: -99.506}
-  m_SizeDelta: {x: 400, y: 599}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1428209626
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428209624}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4c027cbff57d2046ac5df791787b4a6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!222 &1428209627
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428209624}
-  m_CullTransparentMesh: 0
---- !u!1 &1542310181
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1542310182}
-  - component: {fileID: 1542310184}
-  - component: {fileID: 1542310183}
-  m_Layer: 5
-  m_Name: Live (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1542310182
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1542310181}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 44551251}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 112, y: 264}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1542310183
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1542310181}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 25be75ea03ae5470aa518a2494887054, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1542310184
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1542310181}
-  m_CullTransparentMesh: 0
---- !u!1 &1551756609
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1551756610}
-  - component: {fileID: 1551756612}
-  m_Layer: 5
-  m_Name: Texts
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1551756610
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1551756609}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 323315404}
-  - {fileID: 940354908}
-  m_Father: {fileID: 1428209625}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000030517578, y: -182.50002}
-  m_SizeDelta: {x: 400, y: 234}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &1551756612
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1551756609}
-  m_CullTransparentMesh: 0
 --- !u!1 &1590874781
 GameObject:
   m_ObjectHideFlags: 0
@@ -1847,6 +1224,125 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1961742590}
   m_CullTransparentMesh: 0
+--- !u!1001 &4877159017508565081
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1662054823}
+    m_Modifications:
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 550
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -99.506
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 599
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847041, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Name
+      value: Lives
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e53800c3f16e410478cc76a676d56757, type: 3}
 --- !u!1001 &7638608111007491347
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LoseQuickMode.unity
+++ b/Assets/Scenes/LoseQuickMode.unity
@@ -313,7 +313,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &472117858
 RectTransform:
   m_ObjectHideFlags: 0
@@ -446,6 +446,136 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 664578373}
   m_CullTransparentMesh: 0
+--- !u!1001 &682043967
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1561292759}
+    m_Modifications:
+    - target: {fileID: 4877159017464937484, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: btn
+      value: 
+      objectReference: {fileID: 1383959007}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -641.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -78
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 599
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847041, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Name
+      value: Lives
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e53800c3f16e410478cc76a676d56757, type: 3}
+--- !u!224 &682043968 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+    type: 3}
+  m_PrefabInstance: {fileID: 682043967}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &815190980
 GameObject:
   m_ObjectHideFlags: 0
@@ -1405,6 +1535,7 @@ RectTransform:
   - {fileID: 1383959006}
   - {fileID: 1852327904}
   - {fileID: 1320065364}
+  - {fileID: 682043968}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -1611,6 +1611,151 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 624961500}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &627170518
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1557541248}
+    m_Modifications:
+    - target: {fileID: 4877159017464937482, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159017464937484, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: btn
+      value: 
+      objectReference: {fileID: 37012020}
+    - target: {fileID: 4877159018114391323, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 235
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 599
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018227847041, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_Name
+      value: Lives
+      objectReference: {fileID: 0}
+    - target: {fileID: 4877159018407202036, guid: e53800c3f16e410478cc76a676d56757,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e53800c3f16e410478cc76a676d56757, type: 3}
+--- !u!224 &627170519 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4877159018227847040, guid: e53800c3f16e410478cc76a676d56757,
+    type: 3}
+  m_PrefabInstance: {fileID: 627170518}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &745464702
 GameObject:
   m_ObjectHideFlags: 0
@@ -3167,12 +3312,13 @@ RectTransform:
   m_Children:
   - {fileID: 82872210}
   - {fileID: 37012019}
+  - {fileID: 627170519}
   m_Father: {fileID: 829778159}
   m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -11.819}
+  m_AnchoredPosition: {x: 0, y: -11.819031}
   m_SizeDelta: {x: 0, y: 410.14}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1557541249

--- a/Assets/Scripts/QuickGameEventSystem.cs
+++ b/Assets/Scripts/QuickGameEventSystem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class QuickGameEventSystem : MonoBehaviour
+{
+
+    public static QuickGameEventSystem current;
+
+    private void Awake() {
+        current = this;
+    }
+
+    public event Action onTimeframeReached;
+    public void OnTimeframeReached() {
+        if (onTimeframeReached != null) {
+            onTimeframeReached();
+        }
+    }
+
+}

--- a/Assets/Scripts/QuickGameEventSystem.cs.meta
+++ b/Assets/Scripts/QuickGameEventSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4c027cbff57d2046ac5df791787b4a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/QuickGameLives.cs
+++ b/Assets/Scripts/QuickGameLives.cs
@@ -5,8 +5,16 @@ using UnityEngine.UI;
 
 public class QuickGameLives : MonoBehaviour
 {
-    int maxLives = 3;
+    public static int maxLives = 3;
     int currentLives;
+
+    public Button btn;
+
+    void toggleBtn(bool toggle) {
+        if (currentLives == 0) {
+            btn.interactable = toggle;
+        }
+    }
 
     void setCurrentLivesSprites() {
         for(int i = maxLives; i > currentLives; i--) {
@@ -15,8 +23,14 @@ public class QuickGameLives : MonoBehaviour
     }
 
     void regenerateLive() {
+        toggleBtn(true);
         this.transform.GetChild(currentLives).GetComponent<Image>().color = new Color(1f, 1f, 1f, 1f);
         currentLives++;
+        Database.setCurrentLives(GlobalVariables.usernameId, currentLives);
+        Database.removeTimeLastLiveLost(GlobalVariables.usernameId, 1);
+        Database.setFirstTime(GlobalVariables.usernameId);
+        GameMind.saveData();
+        GlobalVariables.currentQuickGameLives = currentLives;
     }
 
     void OnTimeframeReached() {
@@ -26,9 +40,14 @@ public class QuickGameLives : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        currentLives = 0;
+        currentLives = GlobalVariables.currentQuickGameLives;
+        toggleBtn(false);
         setCurrentLivesSprites();
         QuickGameEventSystem.current.onTimeframeReached += OnTimeframeReached;
+    }
+
+    private void Update() {
+        toggleBtn(false);
     }
 
     private void OnDestroy() {

--- a/Assets/Scripts/QuickGameLives.cs
+++ b/Assets/Scripts/QuickGameLives.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class QuickGameLives : MonoBehaviour
+{
+    int maxLives = 3;
+    int currentLives;
+
+    void setCurrentLivesSprites() {
+        for(int i = maxLives; i > currentLives; i--) {
+            this.transform.GetChild(i - 1).GetComponent<Image>().color = new Color(0.5f, 0.5f, 0.5f, 1f);
+        }
+    }
+
+    void regenerateLive() {
+        this.transform.GetChild(currentLives).GetComponent<Image>().color = new Color(1f, 1f, 1f, 1f);
+        currentLives++;
+    }
+
+    void OnTimeframeReached() {
+        regenerateLive();
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        currentLives = 0;
+        setCurrentLivesSprites();
+        QuickGameEventSystem.current.onTimeframeReached += OnTimeframeReached;
+    }
+
+    private void OnDestroy() {
+        QuickGameEventSystem.current.onTimeframeReached -= OnTimeframeReached;
+    }
+}

--- a/Assets/Scripts/QuickGameLives.cs.meta
+++ b/Assets/Scripts/QuickGameLives.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f706e154982af194bbdcd5703e4b90e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/QuickGameLivesTimer.cs
+++ b/Assets/Scripts/QuickGameLivesTimer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -7,8 +8,9 @@ public class QuickGameLivesTimer : MonoBehaviour
 {
 
     Text timer;
-    float timerAmount = 15;
-    float timeRegenerateLive = 5;//1800;
+    float timerAmount = 5400;
+    // cuanto tiempo se tarda en regenerar una vida en segundos
+    float timeRegenerateLive = 1800;
     float hours;
     float minutes;
     float seconds;
@@ -38,20 +40,28 @@ public class QuickGameLivesTimer : MonoBehaviour
         }
     }
 
+    private void Awake() {
+        //obtenido de la base de datos
+        DateTime lastDate = new DateTime(2020, 10, 25, 11, 41, 0);
+        TimeSpan difference;
+
+        difference = System.DateTime.Now - lastDate;
+        //diferencia en segundos
+        print(difference.TotalSeconds);
+        //las cantidad de vidas a regenerar 
+        print(Mathf.FloorToInt((float)difference.TotalSeconds / timeRegenerateLive));
+        //el tiempo actual del reloj
+        timerAmount -= (float)difference.TotalSeconds;
+    }
+
     // Start is called before the first frame update
     void Start()
     {
         timer = GetComponent<Text>();
-        //timerAmount += 1;
-        if (timerAmount > 1) {
+        if (timerAmount > 0) {
             isRunning = true;
         }
         displayCurrentTime();
-    }
-
-    IEnumerator waitBeforeDisappearing() {
-        yield return new WaitForSeconds(0f);
-        this.transform.parent.gameObject.SetActive(false);
     }
 
     void canRegenerateLive() {
@@ -72,7 +82,6 @@ public class QuickGameLivesTimer : MonoBehaviour
                 displayCurrentTime();
             }
             else {
-                //StartCoroutine(waitBeforeDisappearing());
                 this.transform.parent.gameObject.SetActive(false);
                 isRunning = false;
             }

--- a/Assets/Scripts/QuickGameLivesTimer.cs
+++ b/Assets/Scripts/QuickGameLivesTimer.cs
@@ -80,7 +80,7 @@ public class QuickGameLivesTimer : MonoBehaviour
                         Database.setFirstTime(GlobalVariables.usernameId);
                     }
                 }
-                //GlobalVariables.currentQuickGameLives = livesToRegen;
+                GlobalVariables.currentQuickGameLives = livesToRegen;
 
             }
 

--- a/Assets/Scripts/QuickGameLivesTimer.cs
+++ b/Assets/Scripts/QuickGameLivesTimer.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class QuickGameLivesTimer : MonoBehaviour
+{
+
+    Text timer;
+    float timerAmount = 15;
+    float timeRegenerateLive = 5;//1800;
+    float hours;
+    float minutes;
+    float seconds;
+    int lastWhole;
+    bool isRunning;
+
+    string formatTime(float time) {
+
+        string aux = time.ToString();
+
+        if (time < 10) {
+            aux = "0" + aux;
+        }
+
+        return aux;
+    }
+
+    void displayCurrentTime() {
+        hours = Mathf.FloorToInt(timerAmount / 3600);
+        minutes = Mathf.FloorToInt(timerAmount % 3600) / 60;
+        seconds = Mathf.FloorToInt(timerAmount % 60);
+        if (hours != 0) {
+            timer.text = formatTime(hours) + ":" + formatTime(minutes) + ":" + formatTime(seconds);
+        }
+        else {
+            timer.text = formatTime(minutes) + ":" + formatTime(seconds);
+        }
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        timer = GetComponent<Text>();
+        //timerAmount += 1;
+        if (timerAmount > 1) {
+            isRunning = true;
+        }
+        displayCurrentTime();
+    }
+
+    IEnumerator waitBeforeDisappearing() {
+        yield return new WaitForSeconds(0f);
+        this.transform.parent.gameObject.SetActive(false);
+    }
+
+    void canRegenerateLive() {
+        if (Mathf.FloorToInt(timerAmount) % timeRegenerateLive == 0 && lastWhole != Mathf.FloorToInt(timerAmount)) {
+            QuickGameEventSystem.current.OnTimeframeReached();
+            lastWhole = Mathf.FloorToInt(timerAmount);
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (isRunning) {
+            if (Mathf.FloorToInt(timerAmount) > 0) {
+                //print(timerAmount);
+                timerAmount -= Time.deltaTime;
+                canRegenerateLive();
+                displayCurrentTime();
+            }
+            else {
+                //StartCoroutine(waitBeforeDisappearing());
+                this.transform.parent.gameObject.SetActive(false);
+                isRunning = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/QuickGameLivesTimer.cs.meta
+++ b/Assets/Scripts/QuickGameLivesTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 393bf7d0117440542aadb85ae05c96ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.7f1
-m_EditorVersionWithRevision: 2019.3.7f1 (6437fd74d35d)
+m_EditorVersion: 2019.3.6f1
+m_EditorVersionWithRevision: 2019.3.6f1 (5c3fb0a11183)


### PR DESCRIPTION
- Se agrego un sistema de vidas para el modo de juego rapido
- Se despliegan la canitdad de vidas actuales y faltantes junto con un contador que despliega el tiempo faltante para regenerar todas las vidas
- Si el jugador vuelve despues de cierto tiempo, el contador cuenta el tiempo fuera de juego de manera correcta

**Notas**
Actualmente el tiempo a esperar son dos minutos por vida pero esto se puede modificar facilmente
Se necesita borrar la base de datos local para que funcione correctamente
